### PR TITLE
Make 'click elsewhere to close menu' work on iOS Safari.

### DIFF
--- a/js/jquery.dlmenu.js
+++ b/js/jquery.dlmenu.js
@@ -77,7 +77,7 @@
 				else {
 					self._openMenu();
 					// clicking somewhere else makes the menu close
-					$body.off( 'click' ).on( 'click.dlmenu', function() {
+					$body.off( 'click' ).children().on( 'click.dlmenu', function() {
 						self._closeMenu() ;
 					} );
 					


### PR DESCRIPTION
Clicks do not bubble all the way up to the body element in iOS Safari, so "clicking elsewhere" does not close the menu in that browser. Attaching the click handler to immediate children of the body element fixes this.

Note: I was not sure why you are applying the `.off('click')` method just prior to attaching the closing click handler, so I left that alone and added `.children()` after it. Please advise if you'd like me to change that in some way.

Also, this is my first Pull Request, so please be gentle if I've done it wrong :)
