### PR TITLE
Added override property for $trigger; added onNavOpened() and onNavClosed() callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ I changed it to allow for an alternate $trigger (jQuery collection).
 I also added onNavOpened() and onNavClosed() callbacks to allow for running code after these events occur.
 
 
+
+Orig README:: ResponsiveMultiLevelMenu
+========
+
 A responsive multi-level menu that shows its submenus in their own context, allowing for a space-saving presentation and usage.
 
 [article on Codrops](http://tympanus.net/codrops/?p=14753)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 ResponsiveMultiLevelMenu
 =========
 
+This is a forked version of this library.
+
+I changed it to allow for an alternate $trigger (jQuery collection).
+
+I also added onNavOpened() and onNavClosed() callbacks to allow for running code after these events occur.
+
+
 A responsive multi-level menu that shows its submenus in their own context, allowing for a space-saving presentation and usage.
 
 [article on Codrops](http://tympanus.net/codrops/?p=14753)

--- a/README.md
+++ b/README.md
@@ -8,9 +8,26 @@ I changed it to allow for an alternate $trigger (jQuery collection).
 
 I also added onNavOpened() and onNavClosed() callbacks to allow for running code after these events occur.
 
+The example use of this file is contained in index2.html:
+
+    <script>
+        $(function() {
+            var $trigger = $(".alt.dl-trigger");
+            $( '#dl-menu' ).dlmenu({
+                animationClasses : { classin : 'dl-animate-in-2', classout : 'dl-animate-out-2' },
+                triggerEl: $trigger,
+                onNavOpened: function(){
+                    $(".status").text("nav-open");
+                },
+                onNavClosed: function(){
+                    $(".status").text("nav-closed");
+                }
+            });
+        });
+    </script>
 
 
-Orig README:: ResponsiveMultiLevelMenu
+Orig README:: 
 ========
 
 A responsive multi-level menu that shows its submenus in their own context, allowing for a space-saving presentation and usage.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ I changed it to allow for an alternate $trigger (jQuery collection).
 
 I also added onNavOpened() and onNavClosed() callbacks to allow for running code after these events occur.
 
-The example use of this file is contained in index2.html:
+index2.html contains this new use case:
 
     <script>
         $(function() {

--- a/index2.html
+++ b/index2.html
@@ -2,26 +2,26 @@
 <html lang="en" class="no-js">
 	<head>
 		<meta charset="UTF-8" />
-		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"> 
-		<meta name="viewport" content="width=device-width, initial-scale=1.0"> 
+		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<title>Responsive Multi-Level Menu - Demo 2</title>
 		<meta name="description" content="Responsive Multi-Level Menu: Space-saving drop-down menu with subtle effects" />
 		<meta name="keywords" content="multi-level menu, mobile menu, responsive, space-saving, drop-down menu, css, jquery" />
 		<meta name="author" content="Codrops" />
-		<link rel="shortcut icon" href="../favicon.ico"> 
+		<link rel="shortcut icon" href="../favicon.ico">
 		<link rel="stylesheet" type="text/css" href="css/default.css" />
 		<link rel="stylesheet" type="text/css" href="css/component.css" />
 		<script src="js/modernizr.custom.js"></script>
 	</head>
 	<body>
-		<div class="container demo-2">	
+		<div class="container demo-2">
 			<!-- Codrops top bar -->
 			<div class="codrops-top clearfix">
 				<a href="http://tympanus.net/Tutorials/AppShowcase/"><strong>&laquo; Previous Demo: </strong>App Showcase</a>
 				<span class="right"><a href="http://tympanus.net/codrops/?p=14753"><strong>Back to the Codrops Article</strong></a></span>
 			</div><!--/ Codrops top bar -->
 			<header class="clearfix">
-				<h1>Responsive Multi-Level Menu <span>Space-saving drop-down menu with subtle effects</span></h1>	
+				<h1>Responsive Multi-Level Menu <span>Space-saving drop-down menu with subtle effects</span></h1>
 				<nav class="codrops-demos">
 					<a href="index.html">Demo 1</a>
 					<a class="current-demo" href="index2.html">Demo 2</a>
@@ -29,6 +29,8 @@
 					<a href="index4.html">Demo 4</a>
 					<a href="index5.html">Demo 5</a>
 				</nav>
+				<button class="alt dl-trigger">Open Menu </button>
+				<h4 class="status"></h4>
 			</header>
 			<div class="main clearfix">
 				<div class="column">
@@ -143,8 +145,16 @@
 		<script src="js/jquery.dlmenu.js"></script>
 		<script>
 			$(function() {
+				var $trigger = $(".alt.dl-trigger");
 				$( '#dl-menu' ).dlmenu({
-					animationClasses : { classin : 'dl-animate-in-2', classout : 'dl-animate-out-2' }
+					animationClasses : { classin : 'dl-animate-in-2', classout : 'dl-animate-out-2' },
+					triggerEl: $trigger,
+					onNavOpened: function(){
+						$(".status").text("nav-open");
+					},
+					onNavClosed: function(){
+						$(".status").text("nav-closed");
+					}
 				});
 			});
 		</script>

--- a/js/jquery.dlmenu.js
+++ b/js/jquery.dlmenu.js
@@ -26,10 +26,12 @@
 		animationClasses : { classin : 'dl-animate-in-1', classout : 'dl-animate-out-1' },
 		// callback: click a link that has a sub menu
 		// el is the link element (li); name is the level name
-		onLevelClick : function( el, name ) { return false; },
+		onLevelClick : function( el, name ) {return false; },
 		// callback: click a link that does not have a sub menu
 		// el is the link element (li); ev is the event obj
-		onLinkClick : function( el, ev ) { return false; },
+		onLinkClick : function( el, ev ) {return false; },
+		onNavOpened : function() {return false; },
+		onNavClosed : function() {return false; },
 		backLabel: 'Back',
 		// Change to "true" to use the active item as back link label.
 		useActiveItemAsBackLabel: false,
@@ -37,7 +39,8 @@
 		// menu.
 		useActiveItemAsLink: false,
 		// On close reset the menu to root
-		resetOnClose: true
+		resetOnClose: true,
+		triggerEl: ""
 	};
 
 	$.DLMenu.prototype = {
@@ -74,7 +77,7 @@
 		},
 		_config : function() {
 			this.open = false;
-			this.$trigger = this.$el.children( '.dl-trigger' );
+			this.$trigger = this.options.triggerEl || this.$el.children( '.dl-trigger' );
 			this.$menu = this.$el.children( 'ul.dl-menu' );
 			this.$menuitems = this.$menu.find( 'li:not(.dl-back)' );
 			this.$el.find( 'ul.dl-submenu' ).prepend( '<li class="dl-back"><a href="#">' + this.options.backLabel + '</a></li>' );
@@ -221,6 +224,7 @@
 			}
 
 			this.open = false;
+			self.options.onNavClosed();
 		},
 		openMenu : function() {
 			if( !this.open ) {
@@ -238,6 +242,7 @@
 			} );
 			this.$trigger.addClass( 'dl-active' );
 			this.open = true;
+			self.options.onNavOpened();
 		},
 		// resets the menu to its original state (first level of options)
 		_resetMenu : function() {


### PR DESCRIPTION
I added ability to specify an alternate trigger in the case where your trigger is somewhere else in the DOM.  I also added onNavOpened() & onNavClosed() callbacks to do stuff after opening/closing, like toggling a class in that other DOM location to keep things in sync- like a bg overlay/screen for example.
