### PR TITLE
Fix for clicking elsewhere closes menu

### DIFF
--- a/js/jquery.dlmenu.js
+++ b/js/jquery.dlmenu.js
@@ -230,7 +230,7 @@
 		_openMenu : function() {
 			var self = this;
 			// clicking somewhere else makes the menu close
-			$body.off( 'click' ).on( 'click.dlmenu', function() {
+			$('body').on( 'click.dlmenu', function() {
 				self._closeMenu() ;
 			} );
 			this.$menu.addClass( 'dl-menuopen dl-menu-toggle' ).on( this.transEndEventName, function() {


### PR DESCRIPTION
The menu wasn't closing when clicking outside of it. Also, it shouldn't remove all click handlers from the body.
